### PR TITLE
:sparkles: Add refreshStyles ref method for style recalculation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to this project will be documented in this file.
 
+## [1.14.0] - 2023-09-28
+
+### Added
+
+- Added `refreshStyles` ref method to recalculate styles for scenarios where the font size changes or the window is resized.
+
+
 ## [1.13.1] - 2023-09-08
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -78,27 +78,27 @@ For more examples of usage and available options, check out the [demo page](http
 | valueClassName          | `string`                                              |                                        | The class name for the value of the slot, making it possible to customize the styling and visibility of the value.                              |
 | sequentialAnimationMode | `boolean`                                             | `false`                                | Determines if the animation should increment or decrement sequentially from the startValue to value instead of random animation.                |
 | useMonospaceWidth       | `boolean`                                             | `false`                                | Ensures that all numeric characters occupy the same horizontal space, just like they would in a monospace font.                                 |
+| direction               | `string`                                              | `'bottom-top'`                         | Sets the direction of the slot machine animation. Accepted values are `'bottom-top'` and `'top-bottom'`.                                        |
 | debounceDelay           | `number`                                              | `0`                                    | Specifies the delay in milliseconds for debouncing animations. When the value changes rapidly, it allows the animation to execute smoothly.     |
 
 ## 🤖 Ref
 
 You can manipulate the SlotCounter component's behavior using a ref.
 
-| Method           | Type                          | Description                                                                      |
-| ---------------- | ----------------------------- | -------------------------------------------------------------------------------- |
-| `startAnimation` | `(options?: Options) => void` | Initiates the animation of the component with optional customization parameters. |
+| Method           | Type                          | Description                                                                                                                                                                    |
+| ---------------- | ----------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `refreshStyles`  | `() => void`                  | Recalculates the styles for the SlotCounter component. Useful for scenarios where the font size changes or the window is resized, forcing a re-render to apply the new styles. |
+| `startAnimation` | `(options?: Options) => void` | Initiates the animation of the component with optional customization parameters.                                                                                               |
 
-### Options Object
+### Options for `startAnimation` Method
 
-The `options` object accepts the following properties for customizing the component's behavior:
+| Property              | Type     | Optional | Default        | Description                                                                                                                                      |
+| --------------------- | -------- | -------- | -------------- | ------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `duration`            | `number` | Yes      | None           | A number representing the duration of the animation in seconds. Overrides the `duration` prop if provided.                                       |
+| `dummyCharacterCount` | `number` | Yes      | None           | A number indicating how many dummy characters should be shown before the target character. Overrides the `dummyCharacterCount` prop if provided. |
+| `direction`           | `string` | Yes      | `'bottom-top'` | Sets the direction of the slot machine animation. Accepted values: `'bottom-top'`, `'top-bottom'`. Overrides the `direction` prop if provided.   |
 
-- **`duration`**: (Optional) A number representing the duration of the animation in seconds. This will override the `duration` prop if provided.
-- **`dummyCharacterCount`**: (Optional) A number indicating how many dummy characters should be shown in the animation before the target character is displayed. This will override the `dummyCharacterCount` prop if provided.
-- **`direction`**: (Optional) A string that sets the direction of the slot machine animation. Accepted values are `'bottom-top'` and `'top-bottom'`. The default value is `'bottom-top'`.
-  - **`'bottom-top'`**: The animation will start from the bottom and move towards the top.
-  - **`'top-bottom'`**: The animation will start from the top and move downwards.
-
-Example:
+Ref Example:
 
 ```jsx
 import React, { useRef } from 'react';

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-slot-counter",
-  "version": "1.13.1",
+  "version": "1.14.0",
   "description": "Make Your Numbers Pop: Simple and Dynamic Counters for Your UI",
   "author": "almond-bongbong",
   "license": "MIT",
@@ -15,6 +15,7 @@
     "build": "rollup -c",
     "build:watch": "rollup -c -w",
     "dev": "npm run build:watch && cd ./example && npm run start",
+    "dev:example": "cd ./example && npm run start",
     "predeploy": "cd example && yarn install && yarn build",
     "deploy": "gh-pages -d example/build"
   },

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -30,11 +30,11 @@ interface Props {
   dummyCharacters?: string[] | JSX.Element[];
   dummyCharacterCount?: number;
   autoAnimationStart?: boolean;
+  animateUnchanged?: boolean;
+  hasInfiniteList?: boolean;
   containerClassName?: string;
   charClassName?: string;
   separatorClassName?: string;
-  animateUnchanged?: boolean;
-  hasInfiniteList?: boolean;
   valueClassName?: string;
   sequentialAnimationMode?: boolean;
   useMonospaceWidth?: boolean;
@@ -80,6 +80,7 @@ function SlotCounter(
   const animationExecuteCountRef = useRef(0);
   const [dummyList, setDummyList] = useState<(string | number | JSX.Element)[]>([]);
   const animationTimerRef = useRef<number>();
+  const [key, setKey] = useState(0);
 
   const effectiveDummyCharacterCount =
     startAnimationOptionsRef.current?.dummyCharacterCount ?? dummyCharacterCount;
@@ -110,7 +111,7 @@ function SlotCounter(
     : valueRef.current?.toString().split('') ?? [];
 
   const valueList = useMemo(
-    () => (Array.isArray(value) ? value : value.toString().split('')),
+    () => (Array.isArray(value) ? value : value?.toString().split('')),
     [value],
   );
   const startValueList = useMemo(
@@ -184,6 +185,10 @@ function SlotCounter(
     [value],
   );
 
+  const refreshStyles = useCallback(() => {
+    setKey((prev) => prev + 1);
+  }, []);
+
   useEffect(() => {
     if (prevValueRef.current == null) return;
     startAnimation();
@@ -195,10 +200,11 @@ function SlotCounter(
 
   useImperativeHandle(ref, () => ({
     startAnimation: startAnimationAll,
+    refreshStyles,
   }));
 
   return (
-    <span className={mergeClassNames(containerClassName, styles.slot_wrap)}>
+    <span key={key} className={mergeClassNames(containerClassName, styles.slot_wrap)}>
       {valueList.map((v, i) => {
         const isChanged = isChangedValueIndexList.includes(i);
         const delay = (isChanged ? isChangedValueIndexList.indexOf(i) : 0) * calculatedInterval;

--- a/src/types/common.ts
+++ b/src/types/common.ts
@@ -10,4 +10,5 @@ export type StartAnimationOptions = {
 
 export interface SlotCounterRef {
   startAnimation: (options?: StartAnimationOptions) => void;
+  refreshStyles: () => void;
 }


### PR DESCRIPTION
# Description
This PR introduces a new ref method named refreshStyles to the SlotCounter component. This method allows users to manually recalculate the styles of the component, which is particularly useful in situations where the font size changes or the window is resized.

# Changes
Added refreshStyles method to the useImperativeHandle hook in SlotCounter.jsx.
Updated the README.md to document the usage of refreshStyles.
Added test cases for the new ref method.

# Screenshots
No UI changes

# Documentation
- [x] I have updated the documentation accordingly.

