### PR TITLE
:sparkles: Add pre-release support in GitHub Actions

### DIFF
--- a/.github/workflows/publish_to_github.yml
+++ b/.github/workflows/publish_to_github.yml
@@ -3,10 +3,6 @@ name: Publish Github Package
 on:
   release:
     types: [created]
-#on:
-#  push:
-#    branches:
-#      - main
 
 jobs:
   build:
@@ -40,7 +36,16 @@ jobs:
           jq '.name = "@almond-bongbong/react-slot-counter"' package.json > package.temp.json
           mv package.temp.json package.json
 
+      - name: Determine NPM tag
+        id: npm-tag
+        run: |
+          TAG=$(echo "${GITHUB_REF#refs/tags/}" | awk -F '-' '{print $2}')
+          if [ -z "$TAG" ]; then
+            TAG="latest"
+          fi
+          echo "tag=$TAG" >> $GITHUB_ENV
+
       - name: Publish to GitHub Packages
-        run: npm publish
+        run: npm publish --tag ${{ env.tag }}
         env:
           NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/publish_to_npm.yml
+++ b/.github/workflows/publish_to_npm.yml
@@ -3,10 +3,6 @@ name: Publish NPM Package
 on:
   release:
     types: [created]
-#on:
-#  push:
-#    branches:
-#      - main
 
 jobs:
   build:
@@ -27,7 +23,16 @@ jobs:
       - name: Build package
         run: yarn build
 
+      - name: Determine NPM tag
+        id: npm-tag
+        run: |
+          TAG=$(echo "${GITHUB_REF#refs/tags/}" | awk -F '-' '{print $2}')
+          if [ -z "$TAG" ]; then
+            TAG="latest"
+          fi
+          echo "tag=$TAG" >> $GITHUB_ENV
+
       - name: Publish to npm
-        run: npm publish
+        run: npm publish --tag ${{ env.tag }}
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
## Description:

This PR updates the GitHub Actions script to support the publishing of pre-release versions. By determining the appropriate NPM tag based on the release tag, we can effectively manage beta, RC, alpha, and other pre-release versions.

## Changes:

Added Determine NPM tag step:

Extracts the NPM tag from the release tag. For example, if the release tag is v1.0.0-beta.1, it sets the NPM tag to beta. If no tag is specified, it defaults to latest.
Updated Publish to GitHub Packages step:

Modified the npm publish command to include the appropriate NPM tag determined in the previous step.

## Details:

The determine NPM tag step analyzes the GitHub release tag and sets the NPM tag accordingly.
If the release tag follows the format v1.0.0-beta.1, the NPM tag beta is set. If no specific tag is found, it defaults to latest.
When publishing the package, the npm publish command now includes the determined tag.