### PR TITLE
:bug: Prevent infinite ResizeObserver calls during browser zoom

### DIFF
--- a/src/components/Slot.tsx
+++ b/src/components/Slot.tsx
@@ -93,11 +93,14 @@ function Slot({
       return;
     }
 
+    // 1px is the threshold for the font height to be considered changed
+    const THRESHOLD = 1;
+
     const handleResize: ResizeObserverCallback = (entries) => {
       // Change in height
       const height = entries[0].contentRect.height;
 
-      if (fontHeight != height) {
+      if (Math.abs(fontHeight - height) > THRESHOLD) {
         onFontHeightChange?.(height);
       }
     };
@@ -186,9 +189,9 @@ function Slot({
           transform: reverse ? `translateY(-${slotNumbersHeight}px)` : `translateY(0px)`,
           ...(localActive &&
             isChanged && {
-            transform: reverse ? `translateY(0px)` : `translateY(-${slotNumbersHeight}px)`,
-            transition: `transform ${effectiveDuration}s ${delay}s ease-in-out`,
-          }),
+              transform: reverse ? `translateY(0px)` : `translateY(-${slotNumbersHeight}px)`,
+              transition: `transform ${effectiveDuration}s ${delay}s ease-in-out`,
+            }),
         }}
       >
         {didMount ? (


### PR DESCRIPTION
## Description
This PR addresses the issue of ResizeObserver being called infinitely during browser zoom.

## Changes
Added a threshold (1px) to the ResizeObserver callback to ignore minor size changes.
This prevents the infinite loop issue caused by minor size changes during browser zoom.

## Testing
Tested element size changes with browser zoom.
Verified that the onFontHeightChange callback is only called for size changes exceeding the threshold.

## Related Issues
https://github.com/almond-bongbong/react-slot-counter/issues/53