### PR TITLE
:sparkles: Optimize style refresh mechanism for Slot components

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -8,7 +8,7 @@ import React, {
   useRef,
   useState,
 } from 'react';
-import Slot from './components/Slot';
+import Slot, { SlotRef } from './components/Slot';
 import useDebounce from './hooks/useDebounce';
 import useIsomorphicLayoutEffect from './hooks/useIsomorphicLayoutEffect';
 import useValueChangeEffect from './hooks/useValueChangeEffect';
@@ -100,6 +100,7 @@ function SlotCounter(
   const slotCounterRef = useRef<HTMLSpanElement>(null);
   const numbersRef = useRef<HTMLDivElement>(null);
   const startValueRef = useRef(startValue);
+  const slotRefList = useRef<SlotRef[]>([]);
 
   const hasAnimateOnVisible = useMemo(() => {
     if (typeof animateOnVisible === 'boolean') return animateOnVisible;
@@ -299,7 +300,10 @@ function SlotCounter(
    * Refresh styles
    */
   const refreshStyles = useCallback(() => {
-    setKey((prev) => prev + 1);
+    slotRefList.current.forEach((ref) => {
+      ref.refreshStyles();
+    });
+
     detectMaxNumberWidth();
   }, [detectMaxNumberWidth]);
 
@@ -336,6 +340,7 @@ function SlotCounter(
   useImperativeHandle(ref, () => ({
     startAnimation: startAnimationAll,
     refreshStyles,
+    reload: () => setKey((prev) => prev + 1),
   }));
 
   const renderValueList =
@@ -497,6 +502,9 @@ function SlotCounter(
             onFontHeightChange={handleFontHeightChange}
             speed={speed}
             duration={duration}
+            ref={(ref) => {
+              if (ref) slotRefList.current.push(ref);
+            }}
           />
         );
       })}


### PR DESCRIPTION
# Optimize Style Refresh for Slot Counter

## Overview
Implements an optimized style refresh mechanism for Slot Counter component by targeting individual Slot updates instead of triggering full re-renders.

## Changes
- Add `refreshStyles` ref method to Slot component
- Update style refresh logic to handle individual Slots
- Maintain backwards compatibility via SlotCounter's reload method
- Improve performance by reducing unnecessary re-renders

## Technical Implementation
- New `SlotRef` interface for type safety
- Ref collection system using `useRef<SlotRef[]>`
- Individual style refresh handling through `useImperativeHandle`

## Performance
Eliminates unnecessary re-renders by refreshing only affected Slot components while maintaining the same functionality.

Closes #61 