### PR TITLE
Fix #66: Replace import assertions with manual file parsing

### DIFF
--- a/rollup.config.mjs
+++ b/rollup.config.mjs
@@ -7,8 +7,16 @@ import babel from '@rollup/plugin-babel';
 import terser from '@rollup/plugin-terser';
 import eslint from '@rollup/plugin-eslint';
 import banner2 from 'rollup-plugin-banner2';
+import fs from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
 
-import packageJson from './package.json' assert { type: 'json' };
+const configPath = join(
+  dirname(fileURLToPath(import.meta.url)),
+  './package.json'
+);
+const packageJson = JSON.parse(fs.readFileSync(configPath, 'utf8'));
+
 
 const extensions = ['js', 'jsx', 'ts', 'tsx', 'mjs'];
 


### PR DESCRIPTION
This PR resolves issue #66 by replacing import assertions syntax with manual file parsing using the fs module. This ensures compatibility across all Node.js versions, including older versions like 22.x, which do not support the new import attributes syntax.