### PR TITLE
Fix #70: Prevent aria-hidden="true" Elements from Being Selectable 

### DIFF
--- a/src/index.module.scss
+++ b/src/index.module.scss
@@ -20,3 +20,7 @@
 .num {
   display: block;
 }
+
+[aria-hidden="true"] {
+  user-select: none;
+}


### PR DESCRIPTION
This PR addresses issue #70 by adding a CSS rule to exclude elements with the aria-hidden="true" attribute from being selectable. The user-select: none property hidden elements are not inadvertently copied during text selection, improving the ux.