### PR TITLE
Add reload method to SlotCounterRef interface

### DIFF
--- a/src/types/common.ts
+++ b/src/types/common.ts
@@ -23,6 +23,7 @@ export type StartAnimationOptions = {
 export interface SlotCounterRef {
   startAnimation: (options?: StartAnimationOptions) => void;
   refreshStyles: () => void;
+  reload: () => void;
 }
 
 /**


### PR DESCRIPTION
Add missing `reload` method.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new `reload()` method to the public ref API, enabling developers to trigger reload functionality programmatically.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->